### PR TITLE
Handle VLC window per-OS

### DIFF
--- a/video_player.py
+++ b/video_player.py
@@ -1,5 +1,6 @@
 import vlc
 import os
+import sys
 import tkinter as tk
 from tkinter import ttk
 import time
@@ -442,7 +443,20 @@ def initialize_players(files, icon_path=None):
             player = instance.media_player_new()
             media = instance.media_new(file)
             player.set_media(media)
-            player.set_hwnd(frame.winfo_id())
+
+            window_id = frame.winfo_id()
+            try:
+                if os.name == "nt" or sys.platform.startswith("win"):
+                    player.set_hwnd(window_id)
+                elif sys.platform.startswith("linux"):
+                    player.set_xwindow(window_id)
+                elif sys.platform == "darwin":
+                    player.set_nsobject(window_id)
+                else:
+                    log(f"Unsupported platform: {sys.platform}")
+            except Exception as e:
+                log(f"Failed to set window handle on {sys.platform}: {e}")
+
             players.append(player)
             player.play()
             root.update()


### PR DESCRIPTION
## Summary
- add `sys` import
- route VLC window assignment per OS in `initialize_players`
- log unsupported platforms

## Testing
- `python -m py_compile video_player.py main.py navigation.py`

------
https://chatgpt.com/codex/tasks/task_e_6851b449ad8c8329a7f8cd6a53492939